### PR TITLE
fix for deprecated move calls -- mobs are no longer moving under 1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.phar
+build/
+.idea

--- a/Mobsters/src/aliuly/mobsters/idiots/Chicken.php
+++ b/Mobsters/src/aliuly/mobsters/idiots/Chicken.php
@@ -95,7 +95,10 @@ class Chicken extends Animal{
 			$this->lastMotionZ = $this->motionZ;
 
 			foreach($this->hasSpawned as $player){
-				$player->addEntityMotion($this->id, $this->motionX, $this->motionY, $this->motionZ);
+				//$player->addEntityMotion($this->id, $this->motionX, $this->motionY, $this->motionZ);
+				if ($this->chunk != null) {
+					$this->level->addEntityMotion($this->chunk->getX(), $this->chunk->getZ(), $this->getId(), $this->motionX, $this->motionY, $this->motionZ);
+				}
 			}
 		}
 	}

--- a/Mobsters/src/aliuly/mobsters/idiots/Pig.php
+++ b/Mobsters/src/aliuly/mobsters/idiots/Pig.php
@@ -83,7 +83,10 @@ class Pig extends Animal implements Rideable{
 			$this->lastMotionZ = $this->motionZ;
 
 			foreach($this->hasSpawned as $player){
-				$player->addEntityMotion($this->id, $this->motionX, $this->motionY, $this->motionZ);
+				//$player->addEntityMotion($this->id, $this->motionX, $this->motionY, $this->motionZ);
+				if ($this->chunk != null) {
+					$this->level->addEntityMotion($this->chunk->getX(), $this->chunk->getZ(), $this->getId(), $this->motionX, $this->motionY, $this->motionZ);
+				}
 			}
 		}
 	}

--- a/Mobsters/src/aliuly/mobsters/idiots/Wolf.php
+++ b/Mobsters/src/aliuly/mobsters/idiots/Wolf.php
@@ -127,7 +127,10 @@ class Wolf extends Animal implements Tameable{
 			$this->lastMotionZ = $this->motionZ;
 
 			foreach($this->hasSpawned as $player){
-				$player->addEntityMotion($this->id, $this->motionX, $this->motionY, $this->motionZ);
+				if ($this->chunk != null) {
+					$this->level->addEntityMotion($this->chunk->getX(), $this->chunk->getZ(), $this->getId(), $this->motionX, $this->motionY, $this->motionZ);
+				}
+				//$player->addEntityMotion($this->id, $this->motionX, $this->motionY, $this->motionZ);
 			}
 		}
 	}

--- a/Mobsters/src/aliuly/mobsters/idiots/Zombie.php
+++ b/Mobsters/src/aliuly/mobsters/idiots/Zombie.php
@@ -141,7 +141,10 @@ class Zombie extends Monster{
 			$this->lastMotionZ = $this->motionZ;
 
 			foreach($this->hasSpawned as $player){
-				$player->addEntityMotion($this->id, $this->motionX, $this->motionY, $this->motionZ);
+				if ($this->chunk != null) {
+					$this->level->addEntityMotion($this->chunk->getX(), $this->chunk->getZ(), $this->getId(), $this->motionX, $this->motionY, $this->motionZ);
+				}
+			//	$player->addEntityMotion($this->id, $this->motionX, $this->motionY, $this->motionZ);
 			}
 		}
 	}

--- a/Rails/src/aliuly/minecarts/entity/Minecart.php
+++ b/Rails/src/aliuly/minecarts/entity/Minecart.php
@@ -36,8 +36,10 @@ class Minecart extends Vehicle {
     //$pk->speedZ = $this->motionZ;
     $player->dataPacket($pk);
 
-    $player->addEntityMotion($this->getId(), $this->motionX, $this->motionY, $this->motionZ);
-
+   // $player->addEntityMotion($this->getId(), $this->motionX, $this->motionY, $this->motionZ);
+    if ($this->chunk != null) {
+      $this->level->addEntityMotion($this->chunk->getX(), $this->chunk->getZ(), $this->getId(), $this->motionX, $this->motionY, $this->motionZ);
+    }
     parent::spawnTo($player);
   }
 


### PR DESCRIPTION
Version 1.5 of Pocketmine introduced a new movement system and deprecated addEntityMotion.  The result is that mobs no longer move.  I made the following changes to be in line with the new movement code based on changes I observed in the Pocketmine source. 
